### PR TITLE
Remove package.json dependency from DatabricksDriver.ts

### DIFF
--- a/packages/cubejs-databricks-jdbc-driver/src/DatabricksDriver.ts
+++ b/packages/cubejs-databricks-jdbc-driver/src/DatabricksDriver.ts
@@ -27,8 +27,6 @@ import {
 import { DatabricksQuery } from './DatabricksQuery';
 import { downloadJDBCDriver } from './installer';
 
-const { version } = require('../../package.json');
-
 export type DatabricksDriverConfiguration = JDBCDriverConfiguration &
   {
     /**
@@ -210,7 +208,7 @@ export class DatabricksDriver extends JDBCDriver {
           conf?.token ||
           getEnv('databrickToken', { dataSource }) ||
           '',
-        UserAgentEntry: `CubeDev+Cube/${version} (Databricks)`,
+        UserAgentEntry: `CubeDev+Cube (Databricks)`,
       },
       catalog:
         conf?.catalog ||


### PR DESCRIPTION
This aims to solve #6197. The `package.json` file is removed during image build, so the version is never actually used. However, in case there is an exception while connecting to Databricks, the actual exception will be hidden with the error related to this instead. This makes debugging Databricks connection issues impossible.